### PR TITLE
補足説明追加と画像拡大

### DIFF
--- a/books/auto-scaling-2021-confirmation/3-launch-template.md
+++ b/books/auto-scaling-2021-confirmation/3-launch-template.md
@@ -16,7 +16,7 @@ title: "スケジュールスケーリング（１）~起動テンプレート�
 
 以下の内容を設定します。
 起動テンプレート名　`autoscaling-handson20211013`　を入力
-Amazon マシンイメージ（AMI）　`Amazon Linux 2 AMI (HVM), SSD Volume Type` を選択
+Amazon マシンイメージ（AMI）　`Amazon Linux 2 AMI (HVM), SSD Volume Type(64ビット(x86))`
 インスタンスタイプ　t2.micro を選択
 セキュリティグループ　h4b-ec2-sg
 

--- a/books/auto-scaling-2021-confirmation/4-scaleout.md
+++ b/books/auto-scaling-2021-confirmation/4-scaleout.md
@@ -20,7 +20,7 @@ EC2 Instance Connectのタブにて`接続`をクリックします。
 
 コンソール画面が表示されるので、先程ダウンロードしたコマンドを入力し、画面のようになることを確認します。
 
-![](https://storage.googleapis.com/zenn-user-upload/f67e57e651f627f0f0301f6f.png)
+![](https://storage.googleapis.com/zenn-user-upload/9fef00838ea69a21947dc838.png)
 
 # CloudWatchアラーム
 


### PR DESCRIPTION
・起動テンプレートでAMIを選択する時にARMとx86のどちらか迷う可能性があったため、補足追加
・コンソール画面について表示を拡大
